### PR TITLE
Fixed empty check of JAVA_HOME (#405)

### DIFF
--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentIT.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentIT.java
@@ -59,7 +59,7 @@ public class JavaAgentIT {
 
         final String javaHome = System.getenv("JAVA_HOME");
         final String java;
-        if (javaHome != null && javaHome.equals("")) {
+        if (javaHome != null && !javaHome.isEmpty()) {
             java = javaHome + "/bin/java";
         } else {
             java = "java";


### PR DESCRIPTION
Seems odd to prepend javaHome only if it is an empty string.  Fixed the backwards empty check.